### PR TITLE
fix: disable source maps in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "gts lint",
     "clean": "gts clean",
-    "build": "npx @vercel/ncc build src/index.ts -o dist --source-map --license LICENSE",
+    "build": "npx @vercel/ncc build src/index.ts -o dist",
     "fix": "gts fix"
   },
   "repository": {


### PR DESCRIPTION
they are not part of the final build and therefore result in an error