### PR TITLE
Improve CI hygiene, metadata, and documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "gh-action-terragrunt-report",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-24-bookworm",
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,10 @@ name: PR
 on:
   pull_request:
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   test:
     name: 'Terragrunt'
@@ -29,12 +33,11 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
+      - run: npm run lint
       - run: npm run build
-      - name: Report plans with pretty name
+      - name: Report plans
         uses: ./
         with:
           pretty_name_regex: '/example_project/?(\w+)?/(\w+).diff'
           pretty_name_separator: '/'
-      - name: Report plans with default name
-        uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published, edited]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - uses: hernanvicente/build-and-tag-action@v2
         env:

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ This can be done with the help of [`extra_arguments`](https://terragrunt.gruntwo
 terraform {
   extra_arguments "plan-output" {
     commands = ["plan"]
-    arguments = ["-out=${path_relative_from_include()}/${path_relative_to_include()}.tfplan"]
+    arguments = [
+      "-out=${get_terragrunt_dir()}/${basename(path_relative_to_include())}.tfplan"
+    ]
   }
 
   after_hook "plan_diff" {
-    commands     = ["plan"]
-    execute      = ["bash", "-c", "terraform show -no-color ${path_relative_from_include()}/${path_relative_to_include()}.tfplan > ${path_relative_from_include()}/${path_relative_to_include()}.diff"]
+    commands = ["plan"]
+    execute  = ["bash", "-c", "terraform show -no-color ${get_terragrunt_dir()}/${basename(path_relative_to_include())}.tfplan > ${get_terragrunt_dir()}/${basename(path_relative_to_include())}.diff"]
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/littldr/gh-action-terragrunt-report.git"
+    "url": "git+https://github.com/visable-dev/gh-action-terragrunt-report.git"
   },
   "engines": {
     "node": ">=24"
@@ -29,9 +29,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/littldr/gh-action-terragrunt-report/issues"
+    "url": "https://github.com/visable-dev/gh-action-terragrunt-report/issues"
   },
-  "homepage": "https://github.com/littldr/gh-action-terragrunt-report#readme",
+  "homepage": "https://github.com/visable-dev/gh-action-terragrunt-report#readme",
   "dependencies": {
     "@actions/artifact": "^2.2.1",
     "@actions/core": "^1.11.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ async function run() {
           .join(inputs.pretty_name_separator); // join with defined separator
       } else {
         core.warning(
-          `No match found for filename '${prettyFilename} with pretty_name_regex ${prettyNameRegex}.'`,
+          `No match found for filename '${prettyFilename}' with pretty_name_regex ${prettyNameRegex}.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- Add explicit `permissions` to PR and release workflows
- Switch CI from `npm install` to `npm ci` and run `npm run lint` in PR pipeline
- Remove duplicate report step that created two sets of status checks per PR
- Point `package.json` repository metadata to `visable-dev`
- Update devcontainer image to Node 24
- Align README terragrunt hook example with current Terragrunt path helpers
- Fix typo in `pretty_name_regex` warning message

## Context

Follow-up cleanup after the Node 24 / Terraform 1.13.5 / Terragrunt 0.93.8 migration in v2.4.0.

## Test plan

- [ ] PR workflow passes (terragrunt plan, lint, build, single report step)
- [ ] PR shows only one set of terragrunt report status checks


Made with [Cursor](https://cursor.com)