### PR TITLE
Fix release workflow git author identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           workdir="$(mktemp -d)"
           cp action.yml "$workdir/"
           cp -r dist "$workdir/"
 
           cd "$workdir"
           git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add action.yml dist
           git commit -q -m "Build action for release ${TAG}"
           git branch -M release


### PR DESCRIPTION
## Summary

- Move `git config user.name` / `user.email` to after `git init` in the temporary release build directory.
- Fixes `fatal: empty ident name` when publishing compiled `action.yml` + `dist/` to release tags.

## Context

Release v2.4.2 failed because git identity was configured in the checkout repo, not in the orphan commit directory used for tag pushes.

## Test plan

- [ ] Merge and re-run the failed release workflow (edit/republish v2.4.2) or cut v2.4.3


Made with [Cursor](https://cursor.com)